### PR TITLE
include scores because we use the scores in `result_to_json`

### DIFF
--- a/run_model.lua
+++ b/run_model.lua
@@ -64,6 +64,7 @@ function run_image(model, img_path, opt, dtype)
 
   local out = {
     img = img,
+    scores = scores,
     boxes = boxes_xywh,
     captions = captions,
   }


### PR DESCRIPTION
We use `scores` in `result_to_json`, but we can not pass `scores` from `run_image`, so we met the error in `result_to_json`.

so, this PR makes `run_image` return the scores.

Thank you for your great research 👍🏻